### PR TITLE
Http Headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,10 +2582,12 @@ name = "otel"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "http 1.3.1",
  "opentelemetry",
  "sdk-http",
  "sdk-otel",
  "serde_json",
+ "tower-http",
  "tracing",
  "wasi 0.14.7+wasi-0.2.4",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,9 +26,13 @@ dependencies = ["clean"]
 
 [tasks.test]
 command = "cargo"
-args = ["nextest", "run"]
+args = ["nextest", "run", "--all", "--all-features", "--no-tests=pass"]
 dependencies = ["clean"]
 env = { RUSTFLAGS = "-Dwarnings" }
+
+[tasks.test-doc]
+command = "cargo"
+args = ["test", "--doc", "--all-features", "--workspace"]
 
 # -------------------------------------
 # Basic hygiene
@@ -50,6 +54,35 @@ command = "cargo"
 args = ["clippy", "--all-features"]
 install_crate = { rustup_component_name = "clippy" }
 
+[tasks.vet-imports]
+command = "cargo"
+args = ["vet", "regenerate", "imports"]
+install_crate = "cargo-vet"
+
+[tasks.vet-exempt]
+command = "cargo"
+args = ["vet", "regenerate", "exemptions"]
+install_crate = "cargo-vet"
+
+[tasks.vet-unpub]
+command = "cargo"
+args = ["vet", "regenerate", "unpublished"]
+install_crate = "cargo-vet"
+
+[tasks.vet]
+command = "cargo"
+args = ["vet", "--locked"]
+install_crate = "cargo-vet"
+dependencies = ["vet-imports", "vet-exempt", "vet-unpub"]
+
+[tasks.miri]
+script = '''
+rustup +nightly component add miri
+rustup override set nightly
+cargo miri setup
+cargo miri nextest run --no-tests=pass
+'''
+
 [tasks.audit]
 command = "cargo"
 args = ["audit"]
@@ -61,8 +94,17 @@ install_crate = "cargo-machete"
 
 [tasks.outdated]
 command = "cargo"
-args = ["outdated", "--workspace", "--exit-code", "1"]
+args = ["outdated", "--workspace", "--exit-code", "1", "--depth", "1", "--ignore", "prost"]
 install_crate = "cargo-outdated"
+
+[tasks.deny]
+command = "cargo"
+args = ["deny", "--workspace", "check"]
+install_crate = "cargo-deny"
 
 [tasks.check]
 dependencies = ["audit", "fmt", "lint", "outdated", "unused"]
+
+# Emulate CI
+[tasks.ci]
+dependencies = ["lint", "test", "test-doc", "vet", "miri", "outdated", "deny"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -77,8 +77,9 @@ dependencies = ["vet-imports", "vet-exempt", "vet-unpub"]
 
 [tasks.miri]
 script = '''
-rustup +nightly component add miri
 rustup override set nightly
+rustup +nightly component add miri
+rustup +nightly target add aarch64-apple-darwin
 cargo miri setup
 cargo miri nextest run --no-tests=pass
 '''

--- a/crates/sdk-http/src/router.rs
+++ b/crates/sdk-http/src/router.rs
@@ -29,7 +29,7 @@ pub fn serve(
         .map_err(|e| error!("issue processing request: {e}"))?;
 
     // convert axum `Response` to `OutgoingResponse`
-    let response:Response = http_resp.try_into()
+    let response: Response = http_resp.try_into()
         .map_err(|e| error!("issue converting response: {e}"))?;
     Ok(response.0)
 }

--- a/crates/sdk-http/src/router.rs
+++ b/crates/sdk-http/src/router.rs
@@ -1,12 +1,11 @@
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use axum::body::Body;
-use axum::http::Request as HttpRequest;
+use axum::http::{Request as HttpRequest, Response as HttpResponse};
 use futures::StreamExt;
 use futures::executor::block_on;
-use http::header::CONTENT_TYPE;
 use http::{HeaderName, HeaderValue, Uri};
 use percent_encoding::percent_decode_str;
 use tower::ServiceExt;
@@ -29,48 +28,10 @@ pub fn serve(
     let http_resp = block_on(async { router.oneshot(http_req).await })
         .map_err(|e| error!("issue processing request: {e}"))?;
 
-    // transform `http::Response` into `OutgoingResponse`
-    let headers = Headers::new();
-    headers
-        .set(CONTENT_TYPE.as_str(), &[b"application/json".to_vec()])
-        .map_err(|e| error!("issue setting header: {e}"))?;
-    let response = OutgoingResponse::new(headers);
-    response
-        .set_status_code(http_resp.status().as_u16())
-        .map_err(|()| error!("issue setting status code"))?;
-
-    // write `OutgoingBody`
-    let http_body = http_resp.into_body();
-    let mut http_stream = http_body.into_data_stream();
-    let out_body = response.body().map_err(|()| error!("issue getting outgoing body"))?;
-    let out_stream = out_body.write().map_err(|()| error!("issue getting body stream"))?;
-
-    let pollable = out_stream.subscribe();
-    while let Some(Ok(chunk)) = block_on(async { http_stream.next().await }) {
-        pollable.block();
-        out_stream.check_write().map_err(|e| error!("issue checking write: {e}"))?;
-
-        if let Err(e) = out_stream.write(&chunk) {
-            return Err(error!("issue writing to stream: {e}"));
-        }
-    }
-    if let Err(e) = out_stream.flush() {
-        return Err(error!("issue flushing stream: {e}"));
-    }
-    pollable.block();
-
-    // check for errors
-    if let Err(e) = out_stream.check_write() {
-        return Err(error!("issue writing to stream: {e}"));
-    }
-    drop(pollable);
-    drop(out_stream);
-
-    if let Err(e) = OutgoingBody::finish(out_body, None) {
-        return Err(error!("issue finishing body: {e}"));
-    }
-
-    Ok(response)
+    // convert axum `Response` to `OutgoingResponse`
+    let response:Response = http_resp.try_into()
+        .map_err(|e| error!("issue converting response: {e}"))?;
+    Ok(response.0)
 }
 
 struct Request(IncomingRequest);
@@ -124,14 +85,69 @@ impl TryFrom<Request> for HttpRequest<Body> {
         let bytes = request.body()?;
         let body = if bytes.is_empty() { Body::empty() } else { Body::from(bytes) };
 
-        let mut http_req = HttpRequest::builder().method(method.as_str()).uri(uri).body(body)?;
+        let mut http_req = HttpRequest::builder().method(method.as_str()).uri(&uri).body(body)?;
         for (key, value) in headers.entries() {
             let Ok(name) = HeaderName::from_str(&key) else { continue };
             let Ok(value) = HeaderValue::from_bytes(&value) else { continue };
             http_req.headers_mut().insert(name, value);
         }
+        if http_req.headers().get("host").is_none()
+            && let Some(authority) = uri.authority()
+            && let Ok(value) = HeaderValue::from_str(authority.as_str())
+        {
+            http_req.headers_mut().insert("host", value);
+        }
 
         Ok(http_req)
+    }
+}
+
+struct Response(OutgoingResponse);
+
+impl TryInto<Response> for HttpResponse<Body> {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> std::result::Result<Response, Self::Error> {
+        let headers = Headers::new();
+        for (key, value) in self.headers() {
+            headers.set(key.as_str(), &[value.as_bytes().to_vec()])?;
+        }
+        let response = OutgoingResponse::new(headers);
+        response
+            .set_status_code(self.status().as_u16())
+            .map_err(|()| error!("issue setting status code"))?;
+
+        // write `OutgoingBody`
+        let http_body = self.into_body();
+        let mut http_stream = http_body.into_data_stream();
+        let out_body = response.body().map_err(|()| error!("issue getting outgoing body"))?;
+        let out_stream = out_body.write().map_err(|()| error!("issue getting body stream"))?;
+        let pollable = out_stream.subscribe();
+        while let Some(Ok(chunk)) = block_on(async { http_stream.next().await }) {
+            pollable.block();
+            out_stream.check_write().map_err(|e| error!("issue checking write: {e}"))?;
+
+            if let Err(e) = out_stream.write(&chunk) {
+                bail!("issue writing to stream: {e}");
+            }
+        }
+        if let Err(e) = out_stream.flush() {
+            bail!("issue flushing stream: {e}");
+        }
+        pollable.block();
+
+        // check for errors
+        if let Err(e) = out_stream.check_write() {
+            bail!("issue writing to stream: {e}");
+        }
+        drop(pollable);
+        drop(out_stream);
+
+        if let Err(e) = OutgoingBody::finish(out_body, None) {
+            bail!("issue finishing body: {e}");
+        }
+
+        Ok(Response(response))
     }
 }
 

--- a/examples/guests/otel/Cargo.toml
+++ b/examples/guests/otel/Cargo.toml
@@ -13,9 +13,11 @@ workspace = true
 
 [dependencies]
 axum = { workspace = true, features = ["json"] }
+http.workspace = true
 opentelemetry.workspace = true
 sdk-http.workspace = true
 sdk-otel = { workspace = true, features = ["guest-export"] }
 serde_json.workspace = true
+tower-http.workspace = true
 tracing.workspace = true
 wasi.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,7 +3,7 @@
 channel = "stable"
 components = ["clippy", "rust-src", "rustfmt"]
 targets = [
-  "nightly-aarch64-apple-darwin"
+  "nightly-aarch64-apple-darwin",
   "aarch64-apple-darwin",
   "wasm32-wasip2",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,7 @@
 channel = "stable"
 components = ["clippy", "rust-src", "rustfmt"]
 targets = [
+  "nightly-aarch64-apple-darwin"
   "aarch64-apple-darwin",
   "wasm32-wasip2",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,7 +3,6 @@
 channel = "stable"
 components = ["clippy", "rust-src", "rustfmt"]
 targets = [
-  "nightly-aarch64-apple-darwin",
   "aarch64-apple-darwin",
   "wasm32-wasip2",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -574,18 +574,6 @@ criteria = "safe-to-deploy"
 version = "1.0.27"
 criteria = "safe-to-deploy"
 
-[[exemptions.serde]]
-version = "1.0.224"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_core]]
-version = "1.0.224"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_derive]]
-version = "1.0.224"
-criteria = "safe-to-deploy"
-
 [[exemptions.serde_nanos]]
 version = "0.1.4"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2678,6 +2678,241 @@ For more detailed unsafe review notes please see https://crrev.com/c/6362797
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.197"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`, `'\bunsafe\b'`.
+
+There were some hits for `net`, but they were related to serialization and
+not actually opening any connections or anything like that.
+
+There were 2 hits of `unsafe` when grepping:
+* In `fn as_str` in `impl Buf`
+* In `fn serialize` in `impl Serialize for net::Ipv4Addr`
+
+Unsafe review comments can be found in https://crrev.com/c/5350573/2 (this
+review also covered `serde_json_lenient`).
+
+Version 1.0.130 of the crate has been added to Chromium in
+https://crrev.com/c/3265545.  The CL description contains a link to a
+(Google-internal, sorry) document with a mini security review.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.197 -> 1.0.198"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.198 -> 1.0.201"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.201 -> 1.0.202"
+notes = "Trivial changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.202 -> 1.0.203"
+notes = "s/doc_cfg/docsrs/ + tuple_impls/tuple_impl_body-related changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.203 -> 1.0.204"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.204 -> 1.0.207"
+notes = "The small change in `src/private/ser.rs` should have no impact on `ub-risk-2`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.207 -> 1.0.209"
+notes = """
+The delta carries fairly small changes in `src/private/de.rs` and
+`src/private/ser.rs` (see https://crrev.com/c/5812194/2..5).  AFAICT the
+delta has no impact on the `unsafe`, `from_utf8_unchecked`-related parts
+of the crate (in `src/de/format.rs` and `src/ser/impls.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.209 -> 1.0.210"
+notes = "Almost no new code - just feature rearrangement"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Liza Burakova <liza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.210 -> 1.0.213"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.213 -> 1.0.214"
+notes = "No unsafe, no crypto"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.214 -> 1.0.215"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.215 -> 1.0.216"
+notes = "The delta makes minor changes in `build.rs` - switching to the `?` syntax sugar."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.216 -> 1.0.217"
+notes = "Minimal changes, nothing unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.217 -> 1.0.218"
+notes = "No changes outside comments and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.218 -> 1.0.219"
+notes = "Just allowing `clippy::elidable_lifetime_names`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.197"
+notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.197 -> 1.0.201"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.201 -> 1.0.202"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.202 -> 1.0.203"
+notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.203 -> 1.0.204"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.204 -> 1.0.207"
+notes = 'Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.207 -> 1.0.209"
+notes = '''
+There are no code changes in this delta - see https://crrev.com/c/5812194/2..5
+
+I've neverthless also grepped for `-i cipher`, `-i crypto`, `\bfs\b`,
+`\bnet\b`, and `\bunsafe\b`.  There were no hits.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.209 -> 1.0.210"
+notes = "Almost no new code - just feature rearrangement"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Liza Burakova <liza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.210 -> 1.0.213"
+notes = "Grepped for 'unsafe', 'crypt', 'cipher', 'fs', 'net' - there were no hits"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.213 -> 1.0.214"
+notes = "No changes to unsafe, no crypto"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.214 -> 1.0.215"
+notes = "Minor changes should not impact UB risk"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.215 -> 1.0.216"
+notes = "The delta adds `#[automatically_derived]` in a few places.  Still no `unsafe`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.216 -> 1.0.217"
+notes = "No changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.217 -> 1.0.218"
+notes = "No changes outside comments and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.218 -> 1.0.219"
+notes = "Minor changes (clippy tweaks, using `mem::take` instead of `mem::replace`)."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.sha1]]
 who = "David Koloski <dkoloski@google.com>"
 criteria = "safe-to-deploy"
@@ -2959,6 +3194,21 @@ delta = "0.3.1 -> 0.9.0"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.6.4 -> 0.9.3"
+
+[[audits.isrg.audits.serde]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.219 -> 1.0.224"
+
+[[audits.isrg.audits.serde_core]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+version = "1.0.224"
+
+[[audits.isrg.audits.serde_derive]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.219 -> 1.0.224"
 
 [[audits.isrg.audits.sha2]]
 who = "David Cook <dcook@divviup.org>"


### PR DESCRIPTION
Change to `sdk-http`: On translation of an Axum HTTP request to a `wasi-http` request, ensure the authority is attached as a host header. On output, translate the `wasi-http` response to an Axum HTTP Response, including copying headers.